### PR TITLE
Handle and decode "bytes-like" object when parsing the email address

### DIFF
--- a/vrfydmn
+++ b/vrfydmn
@@ -196,8 +196,12 @@ class VrfyDmnMilter(Milter.Base):
             # email address.
             # NOTE: RFC5322 allows a mailbox-list for the From field!
             # Currently this fact is ignored!
-            if "@" in component:
-                email = component
+            if isinstance(component, str):
+                if "@" in component:
+                    email = component
+            else:
+                if b"@" in component:
+                    email = component.decode("utf-8")
 
         email = parseaddr(email)[1]
 


### PR DESCRIPTION
Mails with a header like this:

```
From: =?utf-8?Q?John_M=C3=BCller?= <john.mueller@example.com>
```

… throw a TypeError on our servers:

```
b'<john.mueller@example.com>'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/Milter/__init__.py", line 770, in <lambda>
    milter.set_eoh_callback(lambda ctx: ctx.getpriv().eoh())
  File "./vrfydmn", line 202, in eoh
    if '@' in component:
TypeError: a bytes-like object is required, not 'str'
```

In order to fix that, I added an `isinstance` type check and a `.decode("utf-8")`  before the email address is parsed.

I’m not that proficient in Python, so it is entirely possible that there’s a better way to handle this, but it worked for our (edge?) case and we’d love to see this (or a more elegant solution) merged upstream.