### PR TITLE
Add test mode

### DIFF
--- a/doc/man/man8/vrfydmn.8
+++ b/doc/man/man8/vrfydmn.8
@@ -64,6 +64,10 @@ the from header field with the envelope-from (MAIL FROM) mail address. This opti
 .B -d, --debug
 Run the milter in forground. In this mode, all information concerning an e-mail session will be dumped to standard out. It also will print
 out the result of the check.
+.TP
+.B -t, --test
+Enable test mode: Log actions but always return 'continue' to MTA
+.TP
 .SH SEE ALSO
 vrfydmn_ldap(5)
 .SH BUGS

--- a/vrfydmn
+++ b/vrfydmn
@@ -301,7 +301,7 @@ class VrfyDmnMilter(Milter.Base):
         syslog(LOG_INFO, "%s: header_from=<%s> mail_from=<%s> return_value=%s"
                % (self.getsymval('i'), email, self.__mail_from, result))
 
-        if self.__reject:
+        if self.__reject and not config.test:
             if Cfg.action == Milter.REJECT:
                 self.setreply("554", xcode="5.7.0", msg="Reject Queue-ID: %s - "
                               "RFC5322 from address: <%s>"
@@ -322,6 +322,7 @@ class VrfyDmnMilter(Milter.Base):
                                self.__mail_from))
 
         if self.__dryrun_reject and \
+                not config.test and \
                 self.__email != self.__mail_from:
 
             self.chgheader("From", 0, "<%s>" % self.__mail_from)
@@ -879,6 +880,10 @@ if __name__ == "__main__":
                         default=False,
                         action="store_true",
                         help="Use email as search key, not only the domain")
+    parser.add_argument("--test", "-t",
+                        default=False,
+                        action="store_true",
+                        help="Enable test mode: Log actions but always return 'continue' to MTA")
 
     config = parser.parse_args()
 
@@ -909,7 +914,7 @@ if __name__ == "__main__":
             config.memcached = None
             print("Missing python module memcache!", file=sys.stderr)
 
-    if config.action:
+    if config.action and not config.test:
         if config.action == "accept":
             Cfg.action = Milter.CONTINUE
         elif config.action == "reject":
@@ -922,7 +927,7 @@ if __name__ == "__main__":
         print("Do not use --fix and --opposite together", file=sys.stderr)
         sys.exit(os.EX_USAGE)
 
-    if config.fix:
+    if config.fix and not config.test:
         Cfg.action = Milter.CONTINUE
         Cfg.hold = False
 


### PR DESCRIPTION
Before using this in production, we wanted to plug in the milter and see what **would have happened** with our mails if it was turned on. In order to achieve that, I added an additional flag `-t` or `--test`. With the milter in test mode, it will log the things it **would** do without actually doing it. That gave us confidence to use it in production and would love to see it merged upstream.