### PR TITLE
Sender alignment check

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ in memory. You can send a -HUP signal to the milter to reload its maps and send
 a -USR1 signal to dump all domains to syslog (or stdout, if running in debug
 mode).
 
-For both scenarios described above, you can find a samlpe picture of my current
+For both scenarios described above, you can find a sample picture of my current
 mail system, which demonstrates the usecases
+
+Alternatively you can directly compare the From:-header email domain with the
+envelope sender domain and reject if they are not aligned. This works without
+providing a file, sql or ldap connection.
 
 Features
 ========

--- a/doc/man/man8/vrfydmn.8
+++ b/doc/man/man8/vrfydmn.8
@@ -53,6 +53,9 @@ signal.
 This option specifies a LDAP configuration file. Settings found in this file will enable a persistent LDAP connection. See \fBvrfydmn_ldap\fR(5)
 for the syntax and available options
 .TP
+.B -A, --sender-alignment
+Checks if From: header domain and envelope sender domain are aligned.
+.TP
 .B -m, --memcached SOCKET (default: none)
 A memcached can be wrapped around a LDAP connection. SOCKET is typically 127.0.0.1:11211. Adopt it to your needs, if you want to enable support
 for this option.

--- a/vrfydmn
+++ b/vrfydmn
@@ -233,6 +233,8 @@ class VrfyDmnMilter(Milter.Base):
             self.__dryrun_reject = True
         elif config.opposite:
             self.__reject = False
+        elif config.sender_alignment:
+            self.__reject = False
         else:
             self.__reject = True
 
@@ -281,6 +283,17 @@ class VrfyDmnMilter(Milter.Base):
                             self.__reject = False
                         break
 
+        # Compare From: header domain to envelope sender domain
+        if config.sender_alignment:
+            mail_from_domain = self.__mail_from.split("@")[1]
+            header_from_domain = self.__email.split("@")[1]
+            if config.email:
+                if self.__email != self.__mail_from:
+                    self.__reject = True
+            else:
+                if header_from_domain != mail_from_domain:
+                    self.__reject = True
+
         result = "continue"
         if self.__reject:
             if Cfg.action == Milter.CONTINUE:
@@ -303,9 +316,17 @@ class VrfyDmnMilter(Milter.Base):
 
         if self.__reject:
             if Cfg.action == Milter.REJECT:
-                self.setreply("554", xcode="5.7.0", msg="Reject Queue-ID: %s - "
-                              "RFC5322 from address: <%s>"
-                              % (self.getsymval('i'), self.__email))
+                if config.sender_alignment:
+                    if config.email:
+                        self.setreply("554", xcode="5.7.0", msg="Reject: Email address in From: header %s does not match envelope sender %s"
+                                % (self.__mail_from, self.__email))
+                    else:
+                        self.setreply("554", xcode="5.7.0", msg="Reject: Domain in From: header %s does not match envelope sender %s"
+                                % (self.__mail_from, self.__email))
+                else:
+                    self.setreply("554", xcode="5.7.0", msg="Reject Queue-ID: %s - "
+                                "RFC5322 from address: <%s>"
+                                % (self.getsymval('i'), self.__email))
 
                 return Milter.REJECT
 
@@ -899,8 +920,8 @@ if __name__ == "__main__":
             config.sql = None
             print("Missing python module for SQL!", file=sys.stderr)
 
-    if not (config.file or config.ldap or config.sql):
-        print("You must specify at least one of --file, --ldap or --sql",
+    if not (config.file or config.ldap or config.sql or config.sender_alignment):
+        print("You must specify at least one of --file, --ldap, --sql or --sender-alignment",
               file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
Contrary to the current options (LDAP, SQL or file based) we just needed a way to compare the `From:`  header domain with the envelope sender domain. In case of a mismatch (like `bad@intentions.com` trying to send with a `From:` address like `support@apple.com`), the mail should be rejected. 

I added a new option `-A` or `—sender-alignment` to the milter. Using the sender alignment option, you can run the milter without LDAP, SQL or a domain file. It will do the comparison and reject the mail in case of a mismatch between `From:` header domain and envelope sender domain.

We thought this may be helpful for other people, too. Happy about any suggestions or improvements!